### PR TITLE
Update grunt-typescript to version 0.6.1 (and get typescript compiler 1.4.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/linemanjs/lineman-typescript/issues"
   },
   "dependencies": {
-    "grunt-typescript": "~0.3.6"
+    "grunt-typescript": "^0.6.1"
   },
   "peerDependencies": {
     "lineman": ">= 0.27.0"


### PR DESCRIPTION
I had problems with an earlier version of typescript compiler, in angular.d.ts and jquery.d.ts and updating the grunt-typescript version fix that problem.
